### PR TITLE
KEP-nnnn Removed an extraneous proto from the test_libs variable

### DIFF
--- a/database/test/CMakeLists.txt
+++ b/database/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 set(test_srcs database_test.cpp db_impl_test.cpp ../../mocks/mock_boost_asio_beast.hpp ../../mocks/mock_swarm.hpp ../../mocks/mock_db_impl.hpp)
-set(test_libs database crypto proto bzapi ${Protobuf_LIBRARIES} ${OPENSSL_LIBRARIES})
+set(test_libs database crypto bzapi ${Protobuf_LIBRARIES} ${OPENSSL_LIBRARIES})
 
 add_gmock_test(database)


### PR DESCRIPTION
To get make to build without protobuf errors on my Mac, I needed to remove a proto from one of the cmake files.