### PR TITLE
KEP-1770 Attempting to initialize BZAPI with empty ESR or URL strings…

### DIFF
--- a/library/library.cpp
+++ b/library/library.cpp
@@ -41,6 +41,8 @@ namespace
     int error_val = -1;
     const uint64_t DEFAULT_TIMEOUT = 30;
     uint64_t api_timeout = DEFAULT_TIMEOUT;
+    const char *EMPTY_URL_MESSAGE{"unable to initialize bzapi with an empty ethereum network URL"};
+    const char *EMPTY_ESR_ADDRESS_MESSAGE{"unable to initialize bzapi with an empty Ethereum swarm registry address"};
 }
 
 namespace bzapi
@@ -96,6 +98,26 @@ namespace bzapi
         CATCHALL(do_bad_endpoint(endpoint));
 
         return std::make_pair(addr, port);
+    }
+
+    static bool
+    check_for_empty_addresses(const std::string& esr_address, const std::string& url)
+    {
+        if (url.empty())
+        {
+            error_val = -1;
+            error_str = EMPTY_URL_MESSAGE;
+            return false;
+        }
+
+        if (esr_address.empty())
+        {
+            error_val = -1;
+            error_str = EMPTY_ESR_ADDRESS_MESSAGE;
+            return false;
+        }
+        
+        return true;
     }
 
     static void
@@ -156,6 +178,11 @@ namespace bzapi
     initialize(const std::string& public_key, const std::string& private_key
         , const std::string& esr_address, const std::string& url)
     {
+        if (!check_for_empty_addresses(esr_address, url))
+        {
+            return false;
+        }
+        
         if (!initialized)
         {
             try

--- a/library/test/library_test.cpp
+++ b/library/test/library_test.cpp
@@ -569,6 +569,24 @@ TEST_F(integration_test, test_initialize_fails_with_bad_endpoint)
     EXPECT_EQ(bzapi::get_error_str(), std::string{"Bad Endpoint"});
 }
 
+TEST_F(integration_test, test_initialize_fails_with_empty_esr_address)
+{
+    const std::string EMPTY_ESR_ADDRESS{""};
+    const std::string VALID_URL{"127.0.0.1"};
+    EXPECT_FALSE(bzapi::initialize(pub_key, priv_key, EMPTY_ESR_ADDRESS, VALID_URL));
+    EXPECT_EQ(-1,bzapi::get_error());
+    EXPECT_EQ("unable to initialize bzapi with an empty Ethereum swarm registry address", bzapi::get_error_str());
+}
+
+TEST_F(integration_test, test_initialize_fails_with_empty_URL)
+{
+    const std::string VALID_ESR_ADDRESS{"D5B3d7C061F817ab05aF9Fab3b61EEe036e4f4fc"};
+    const std::string EMPTY_URL{""};
+    EXPECT_FALSE(bzapi::initialize(pub_key, priv_key, VALID_ESR_ADDRESS, EMPTY_URL));
+    EXPECT_EQ(-1,bzapi::get_error());
+    EXPECT_EQ("unable to initialize bzapi with an empty ethereum network URL", bzapi::get_error_str());
+}
+
 TEST_F(integration_test, test_initialize_esr)
 {
     auto esr = std::make_shared<mock_esr>();


### PR DESCRIPTION
… will cause initialization to fail