### PR TITLE
KEP-1811 - Handle incoming messages after swarm destroyed

### DIFF
--- a/crypto/crypto.cpp
+++ b/crypto/crypto.cpp
@@ -157,10 +157,6 @@ crypto::sign(bzn_envelope& msg)
     if (result)
     {
         msg.set_signature(signature.get(), signature_length);
-        if (!this->verify(msg))
-        {
-            LOG(error) << "Can't verify own message";
-        }
     }
     else
     {

--- a/library/test/library_test.cpp
+++ b/library/test/library_test.cpp
@@ -915,11 +915,11 @@ TEST_F(integration_test, blocking_response_test)
 // these tests need to be run manually with an active swarm
 // and need the node id to be set below to the first swarm member
 
-#if 0 // local swarm
+#if 1 // local swarm
 namespace
 {
-    std::string NODE_ID{"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDx3+Pop6RsWWUGCM519/SieCJqq7C/FP1DiXTAV1qpI4VUqrfIPm+ONTyMVspVA6I7ZyW+PExzKJmQom66mp2g=="};
-    std::string endpoint{"ws://localhost:50000"};
+    std::string NODE_ID{"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhplzg8Cv+6WhfhEArLMrSaHxYJCfb71kDpDW4OkLfAPYsXgq9YwbpCfeHkoGdQhtPrm6l0RRcoZQUuCKjaKLug=="};
+    std::string endpoint{"ws://localhost:50003"};
 }
 
 #else // remote swarm

--- a/swarm/swarm.hpp
+++ b/swarm/swarm.hpp
@@ -72,6 +72,7 @@ namespace bzapi
         const uuid_t my_uuid;
 
         bool init_called = false;
+        std::vector<std::pair<node_id_t, bzn::peer_address_t>> initial_nodes;
         completion_handler_t init_handler = nullptr;
         std::unordered_map<payload_t, swarm_response_handler_t> response_handlers;
 
@@ -81,6 +82,7 @@ namespace bzapi
         status_response last_status;
         std::mutex info_mutex;
 
+        void init_nodes();
         void add_nodes(const std::vector<std::pair<node_id_t, bzn::peer_address_t>>& node_list);
         void send_status_request(const uuid_t& node_uuid);
         void send_node_request(const std::shared_ptr<node_base>& node, const bzn_envelope& request);

--- a/swarm/test/swarm_test.cpp
+++ b/swarm/test/swarm_test.cpp
@@ -373,18 +373,18 @@ TEST_F(swarm_test, test_send_policy)
 TEST_F(swarm_test, test_bad_status)
 {
     this->init(200, 1);
-    auto meta = this->nodes[0];
+    auto node = this->nodes[0].node;
 
-    EXPECT_CALL(*meta.node, send_message(_, _)).Times(AtLeast(1))
-        .WillRepeatedly(Invoke([&meta](auto /*msg*/, auto /*callback*/)
+    EXPECT_CALL(*node, send_message(_, _)).Times(AtLeast(1))
+        .WillRepeatedly(Invoke([this](auto /*msg*/, auto /*callback*/)
         {
             // schedule status response
-            auto node = meta.node;
+            auto node = this->nodes[0].node;
 
             bzn_envelope env;
             env.set_status_response("A bunch of garbage");
             auto env_str = env.SerializeAsString();
-            EXPECT_EQ(meta.handler(env_str), true);
+            EXPECT_EQ(this->nodes[0].handler(env_str), true);
         }));
 
     auto l = [](auto& /*ec*/){};


### PR DESCRIPTION
As found using bzapi-cli, it's possible for an unneeded node response to be received after the swarm has been deleted. This was causing a segfault due to the use of a "hard this" in the callback. The hard this was previously used because nodes were added during construction and it wasn't possible to create a weak_ptr yet.